### PR TITLE
Remove obs-vkcapture

### DIFF
--- a/data/generic-flatpaks.txt
+++ b/data/generic-flatpaks.txt
@@ -9,5 +9,4 @@ io.mpv.Mpv
 com.discordapp.Discord
 im.riot.Riot
 com.obsproject.Studio
-com.obsproject.Studio.Plugin.OBSVkCapture
 org.pipewire.Helvum

--- a/scripts/rpm-setup.sh
+++ b/scripts/rpm-setup.sh
@@ -20,10 +20,6 @@ function install_rpms() {
         sudo dnf install -y "${line}"
     done
 
-    # Install obs-vkcapture from copr repo
-    sudo dnf copr enable kylegospo/obs-vkcapture
-    sudo dnf install -y obs-vkcapture.x86_64 obs-vkcapture.i686
-
     # Install mesa-git from copr repo
     sudo dnf copr enable xxmitsu/mesa-git
     sudo dnf upgrade -y --refresh


### PR DESCRIPTION
Since in Wayland PipeWire screen capture is zero-copy with DMA-BUF (at least most of the time), it is unnecessary to install obs-vkcapture.

In X11, however, the performance difference is substantial, but as the use case here is Wayland it is of no concern.