### PR TITLE
Implement GoXLR Utility daemon systemd service

### DIFF
--- a/scripts/00-fedora-postinstall.sh
+++ b/scripts/00-fedora-postinstall.sh
@@ -74,6 +74,7 @@ function remove_default_pkgs() {
 }
 
 gpu_type=$(lspci)
+usb_devices=$(lsusb)
 
 # Update all packages before doing the rest of the setup
 sudo dnf upgrade -y --refresh
@@ -83,11 +84,18 @@ mkdir -p ~/Repos
 prompt_git
 prompt_rpm_fusion_repos
 
+# Handle GPU setup
 if grep -E "NVIDIA|GeForce" <<< ${gpu_type}; then
     install_nvidia_drivers
 elif grep -E "7900 XTX" <<< ${gpu_type}; then
     chmod u+x ./setup-gpu-profile.sh
     ./setup-gpu-profile.sh
+fi
+
+# Handle GoXLR daemon service
+if grep -E "GoXLRMini" <<< ${usb_devices}; then
+    chmod u+x ./goxlr-setup.sh
+    ./goxlr-setup.sh
 fi
 
 remove_default_pkgs

--- a/scripts/goxlr-setup.sh
+++ b/scripts/goxlr-setup.sh
@@ -1,0 +1,5 @@
+# Copy GoXLR Utility service
+sudo cp ./goxlr-utility.service /etc/systemd/user/goxlr-utility.service
+
+# Enable service immediately
+systemctl enable --user --now goxlr-utility.service

--- a/scripts/goxlr-utility.service
+++ b/scripts/goxlr-utility.service
@@ -1,0 +1,9 @@
+[Unit]
+Description = "Handle GoXLR Utility initialization"
+
+[Service]
+ExecStart=/usr/bin/goxlr-daemon
+Type=idle
+
+[Install]
+WantedBy=default.target


### PR DESCRIPTION
This PR implements a user systemd service that is auto-enabled and starts the GoXLR Utility daemon. This service is only added if the host has a GoXLR Mini.