### PR TITLE
Add tide configure command to terminal-setup script

### DIFF
--- a/scripts/terminal-setup.sh
+++ b/scripts/terminal-setup.sh
@@ -11,6 +11,8 @@ function install_terminal() {
     # curl https://codeload.github.com/ilancosman/tide/tar.gz/v6 | tar -xzC $_tide_tmp_dir
     # command cp -R $_tide_tmp_dir/*/{completions,conf.d,functions} $__fish_config_dir
     # fish_path=(status fish-path) exec $fish_path -C "emit _tide_init_install"
+
+    # tide configure --auto --style=Rainbow --prompt_colors='True color' --show_time='12-hour format' --rainbow_prompt_separators=Angled --powerline_prompt_heads=Sharp --powerline_prompt_tails=Flat --powerline_prompt_style='Two lines, frame' --prompt_connection=Disconnected --powerline_right_prompt_frame=Yes --prompt_connection_andor_frame_color=Dark --prompt_spacing=Sparse --icons='Many icons' --transient=Yes
 }
 
 function install_tmux() {


### PR DESCRIPTION
This adds `tide configure` command (commented out) to the `terminal-setup` script. This should be used instead in order to automatically generate tide config files instead of having them be part of the dotfiles.