### PR TITLE
Change goxlr-utility systemd service type

### DIFF
--- a/scripts/goxlr-utility.service
+++ b/scripts/goxlr-utility.service
@@ -1,9 +1,9 @@
 [Unit]
-Description = "Handle GoXLR Utility initialization"
+Description=Handle GoXLR Utility initialization
 
 [Service]
+Type=oneshot
 ExecStart=/usr/bin/goxlr-daemon
-Type=idle
 
 [Install]
 WantedBy=default.target


### PR DESCRIPTION
This PR aims to change the goxlr-utility systemd service from `idle` to `oneshot` as the service should only run once on initialization.