### PR TITLE
Remove GoXLR setup

### DIFF
--- a/scripts/00-fedora-postinstall.sh
+++ b/scripts/00-fedora-postinstall.sh
@@ -92,12 +92,6 @@ elif grep -E "7900 XTX" <<< ${gpu_type}; then
     ./setup-gpu-profile.sh
 fi
 
-# Handle GoXLR daemon service
-if grep -E "GoXLRMini" <<< ${usb_devices}; then
-    chmod u+x ./goxlr-setup.sh
-    ./goxlr-setup.sh
-fi
-
 remove_default_pkgs
 chmod u+x ./flatpak-setup.sh
 ./flatpak-setup.sh

--- a/scripts/goxlr-setup.sh
+++ b/scripts/goxlr-setup.sh
@@ -1,5 +1,0 @@
-# Copy GoXLR Utility service
-sudo cp ./goxlr-utility.service /etc/systemd/user/goxlr-utility.service
-
-# Enable service immediately
-systemctl enable --user --now goxlr-utility.service

--- a/scripts/goxlr-utility.service
+++ b/scripts/goxlr-utility.service
@@ -1,9 +1,0 @@
-[Unit]
-Description=Handle GoXLR Utility initialization
-
-[Service]
-Type=oneshot
-ExecStart=/usr/bin/goxlr-daemon
-
-[Install]
-WantedBy=default.target


### PR DESCRIPTION
The code that was used to setup the GoXLR Mini is no longer relevant due to the following:
- GoXLR Utility has a setting in the application to setup autostart ("AutoStart on Login")
- XDG AutoStart is a more reliable way to setup autostart in this case compared to systemd because XDG AutoStart triggers when desktop environment XDG parameters (and pipewire) are configured