### PR TITLE
Remove favorite apps setup

### DIFF
--- a/data/favorite-apps.txt
+++ b/data/favorite-apps.txt
@@ -1,5 +1,0 @@
-org.gnome.Nautilus.desktop
-org.mozilla.firefox.desktop
-com.vscodium.codium.desktop
-com.discordapp.Discord.desktop
-com.valvesoftware.Steam.desktop

--- a/scripts/de-setup.sh
+++ b/scripts/de-setup.sh
@@ -37,23 +37,6 @@ function handle_gnome_settings() {
         gsettings set org.gnome.desktop.wm.keybindings switch-to-workspace-$i "['<Super>$i']"
         gsettings set org.gnome.desktop.wm.keybindings move-to-workspace-$i "['<Super><Shift>${i}']"
     done
-
-    # Setup favorite apps that appear in the dock
-    setup_favorite_apps
-}
-
-function setup_favorite_apps() {
-    favorite_apps="$(get_favorite_apps)"
-    favorite_apps="[${favorite_apps:2:${#favorite_apps}}]"
-
-    gsettings set org.gnome.shell favorite-apps "$favorite_apps"
-}
-
-get_favorite_apps() {
-    cat "../data/favorite-apps.txt" | while read line
-    do
-        echo -n ", '${line}'"
-    done
 }
 
 function handle_kde_settings() {


### PR DESCRIPTION
This PR removes the favorite apps setup for Gnome. This is done because the dock sees little use on my end.